### PR TITLE
fix typo

### DIFF
--- a/_posts/2017-11-17-understanding-operator-co-await.md
+++ b/_posts/2017-11-17-understanding-operator-co-await.md
@@ -183,13 +183,13 @@ can be translated (roughly) as follows:
     using handle_t = std::experimental::coroutine_handle<P>;
 
     using await_suspend_result_t =
-      decltype(awaiter.await_suspend(handle_t::from_promise(p)));
+      decltype(awaiter.await_suspend(handle_t::from_promise(promise)));
 
     <suspend-coroutine>
 
     if constexpr (std::is_void_v<await_suspend_result_t>)
     {
-      awaiter.await_suspend(handle_t::from_promise(p));
+      awaiter.await_suspend(handle_t::from_promise(promise));
       <return-to-caller-or-resumer>
     }
     else
@@ -198,7 +198,7 @@ can be translated (roughly) as follows:
          std::is_same_v<await_suspend_result_t, bool>,
          "await_suspend() must return 'void' or 'bool'.");
 
-      if (awaiter.await_suspend(handle_t::from_promise(p)))
+      if (awaiter.await_suspend(handle_t::from_promise(promise)))
       {
         <return-to-caller-or-resumer>
       }


### PR DESCRIPTION
There is a `promise` variable at

https://github.com/lewissbaker/lewissbaker.github.io/blob/de4f88e5858f7508830e4a1f3499a50c01b5bac5/_posts/2017-11-17-understanding-operator-co-await.md?plain=1#L179

We use this name.